### PR TITLE
rename tables, require php 7.1, update tests

### DIFF
--- a/Cashier.php
+++ b/Cashier.php
@@ -38,8 +38,10 @@ class Cashier
      *
      * @param string $currency
      * @param string|null $symbol
+     *
+     * @throws Exception
      */
-    public static function useCurrency($currency, $symbol = null)
+    public static function useCurrency(string $currency, ?string $symbol = null): void
     {
         static::$currency = $currency;
         static::useCurrencySymbol($symbol ?: static::guessCurrencySymbol($currency));
@@ -54,7 +56,7 @@ class Cashier
      *
      * @throws Exception
      */
-    protected static function guessCurrencySymbol($currency)
+    protected static function guessCurrencySymbol(string $currency): string
     {
         switch (strtolower($currency)) {
             case 'usd':
@@ -75,7 +77,7 @@ class Cashier
      *
      * @return string
      */
-    public static function usesCurrency()
+    public static function usesCurrency(): string
     {
         return static::$currency;
     }
@@ -85,7 +87,7 @@ class Cashier
      *
      * @param string $symbol
      */
-    public static function useCurrencySymbol($symbol)
+    public static function useCurrencySymbol(string $symbol): void
     {
         static::$currencySymbol = $symbol;
     }
@@ -95,7 +97,7 @@ class Cashier
      *
      * @return string
      */
-    public static function usesCurrencySymbol()
+    public static function usesCurrencySymbol(): string
     {
         return static::$currencySymbol;
     }
@@ -105,7 +107,7 @@ class Cashier
      *
      * @param callable $callback
      */
-    public static function formatCurrencyUsing(callable $callback)
+    public static function formatCurrencyUsing(callable $callback): void
     {
         static::$formatCurrencyUsing = $callback;
     }
@@ -117,7 +119,7 @@ class Cashier
      *
      * @return string
      */
-    public static function formatAmount($amount)
+    public static function formatAmount(int $amount): string
     {
         if (static::$formatCurrencyUsing) {
             return call_user_func(static::$formatCurrencyUsing, $amount);

--- a/README.md
+++ b/README.md
@@ -46,23 +46,23 @@ if ($this->db->driverName === 'mysql') {
     $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
 }
 
-$this->createTable('subscription', [
+$this->createTable('subscriptions', [
     'id' => $this->primaryKey(),
-    'userId' => $this->integer()->notNull(),
+    'user_id' => $this->integer()->notNull(),
     'name' => $this->string()->notNull(),
-    'stripeId' => $this->string()->notNull(),
-    'stripePlan' => $this->string()->notNull(),
+    'stripe_id' => $this->string()->notNull(),
+    'stripe_plan' => $this->string()->notNull(),
     'quantity' => $this->integer()->notNull(),
-    'trialEndAt' => $this->timestamp()->null(),
-    'endAt' => $this->timestamp()->null(),
-    'createdAt' => $this->timestamp()->null(),
-    'updatedAt' => $this->timestamp()->null()
+    'trial_ends_at' => $this->timestamp()->null(),
+    'ends_at' => $this->timestamp()->null(),
+    'created_at' => $this->timestamp()->null(),
+    'updated_at' => $this->timestamp()->null()
 ], $tableOptions);
 
-$this->addColumn('user', 'stripeId', $this->string());
-$this->addColumn('user', 'cardBrand', $this->string());
-$this->addColumn('user', 'cardLastFour', $this->string());
-$this->addColumn('user', 'trialEndAt', $this->timestamp()->null());
+$this->addColumn('users', 'stripe_id', $this->string());
+$this->addColumn('users', 'card_brand', $this->string());
+$this->addColumn('users', 'card_last_four', $this->string());
+$this->addColumn('users', 'trial_ends_at', $this->timestamp()->null());
 ```
 > Also you can apply migration by the following command:
 
@@ -307,7 +307,7 @@ If you would like to offer trial periods without collecting the user's payment m
 ```php
 $user = new User([
     // Populate other user properties...
-    'trialEndAt' => Carbon::now()->addDays(10),
+    'trial_ends_at' => Carbon::now()->addDays(10),
 ]);
 ```
 

--- a/SubscriptionBuilder.php
+++ b/SubscriptionBuilder.php
@@ -183,13 +183,13 @@ class SubscriptionBuilder
             $trialEndsAt = $this->trialDays ? Carbon::now()->addDays($this->trialDays) : null;
         }
         $subscriptionModel = new SubscriptionModel([
-            'userId' => $this->user->id,
+            'user_id' => $this->user->id,
             'name' => $this->name,
-            'stripeId' => $subscription->id,
-            'stripePlan' => $this->plan,
+            'stripe_id' => $subscription->id,
+            'stripe_plan' => $this->plan,
             'quantity' => $this->quantity,
-            'trialEndAt' => $trialEndsAt,
-            'endAt' => null,
+            'trial_ends_at' => $trialEndsAt,
+            'ends_at' => null,
         ]);
         if ($subscriptionModel->save()) {
             return $subscriptionModel;
@@ -208,7 +208,7 @@ class SubscriptionBuilder
      */
     protected function getStripeCustomer($token = null, array $options = [])
     {
-        if (!$this->user->stripeId) {
+        if (!$this->user->stripe_id) {
             $customer = $this->user->createAsStripeCustomer(
                 $token, array_merge($options, array_filter(['coupon' => $this->coupon]))
             );

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": ">=7.1",
         "yiisoft/yii2": "~2.0.14",
         "yii2mod/yii2-behaviors": "*",
         "stripe/stripe-php": "~4.0",

--- a/controllers/WebhookController.php
+++ b/controllers/WebhookController.php
@@ -30,7 +30,7 @@ class WebhookController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'handle-webhook' => ['post'],
                 ],
@@ -46,15 +46,18 @@ class WebhookController extends Controller
     public function actionHandleWebhook()
     {
         $payload = json_decode(Yii::$app->request->getRawBody(), true);
+
         if (!$this->eventExistsOnStripe($payload['id'])) {
             return;
         }
+
         $method = 'handle' . Inflector::camelize(str_replace('.', '_', $payload['type']));
+
         if (method_exists($this, $method)) {
             return $this->{$method}($payload);
-        } else {
-            return $this->missingMethod();
         }
+
+        return $this->missingMethod();
     }
 
     /**
@@ -71,7 +74,7 @@ class WebhookController extends Controller
             $subscriptions = $user->getSubscriptions()->all();
             /* @var $subscription SubscriptionModel */
             foreach ($subscriptions as $subscription) {
-                if ($subscription->stripeId === $payload['data']['object']['id']) {
+                if ($subscription->stripe_id === $payload['data']['object']['id']) {
                     $subscription->markAsCancelled();
                 }
             }
@@ -94,7 +97,7 @@ class WebhookController extends Controller
     {
         $model = Yii::$app->user->identityClass;
 
-        return $model::findOne(['stripeId' => $stripeId]);
+        return $model::findOne(['stripe_id' => $stripeId]);
     }
 
     /**

--- a/migrations/m180321_213759_rename_subscription_table.php
+++ b/migrations/m180321_213759_rename_subscription_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m180321_213759_rename_subscription_table
+ */
+class m180321_213759_rename_subscription_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->renameTable('subscription', 'subscriptions');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->renameTable('subscriptions', 'subscription');
+    }
+}

--- a/migrations/m180321_213856_rename_subscription_columns.php
+++ b/migrations/m180321_213856_rename_subscription_columns.php
@@ -1,0 +1,51 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m180321_213856_rename_subscription_columns
+ */
+class m180321_213856_rename_subscription_columns extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->renameColumn('subscriptions', 'userId', 'user_id');
+        $this->renameColumn('subscriptions', 'stripeId', 'stripe_id');
+        $this->renameColumn('subscriptions', 'stripePlan', 'stripe_plan');
+        $this->renameColumn('subscriptions', 'trialEndAt', 'trial_ends_at');
+        $this->renameColumn('subscriptions', 'endAt', 'ends_at');
+        $this->renameColumn('subscriptions', 'createdAt', 'created_at');
+        $this->renameColumn('subscriptions', 'updatedAt', 'updated_at');
+
+        if (Yii::$app->db->schema->getTableSchema('user')) {
+            $this->renameColumn('user', 'stripeId', 'stripe_id');
+            $this->renameColumn('user', 'cardBrand', 'card_brand');
+            $this->renameColumn('user', 'cardLastFour', 'card_last_four');
+            $this->renameColumn('user', 'trialEndAt', 'trial_ends_at');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->renameColumn('subscriptions', 'user_id', 'userId');
+        $this->renameColumn('subscriptions', 'stripe_id', 'stripeId');
+        $this->renameColumn('subscriptions', 'stripe_plan', 'stripePlan');
+        $this->renameColumn('subscriptions', 'trial_ends_at', 'trialEndAt');
+        $this->renameColumn('subscriptions', 'ends_at', 'endAt');
+        $this->renameColumn('subscriptions', 'created_at', 'createdAt');
+        $this->renameColumn('subscriptions', 'updated_at', 'updatedAt');
+
+        if (Yii::$app->db->schema->getTableSchema('user')) {
+            $this->renameColumn('user', 'stripe_id', 'stripeId');
+            $this->renameColumn('user', 'card_brand', 'cardBrand');
+            $this->renameColumn('user', 'card_last_four', 'cardLastFour');
+            $this->renameColumn('user', 'trial_ends_at', 'trialEndAt');
+        }
+    }
+}

--- a/tests/CashierTest.php
+++ b/tests/CashierTest.php
@@ -32,7 +32,7 @@ class CashierTest extends TestCase
         $user->newSubscription('main', 'monthly-10-1')->create($this->getTestToken());
 
         $this->assertEquals(1, count($user->subscriptions));
-        $this->assertNotNull($user->subscription('main')->stripeId);
+        $this->assertNotNull($user->subscription('main')->stripe_id);
         $this->assertTrue($user->subscribed('main'));
         $this->assertTrue($user->subscribedToPlan('monthly-10-1', 'main'));
         $this->assertFalse($user->subscribedToPlan('monthly-10-1', 'something'));
@@ -52,13 +52,13 @@ class CashierTest extends TestCase
         $this->assertTrue($subscription->onGracePeriod());
 
         // Modify Ends Date To Past
-        $oldGracePeriod = $subscription->endAt;
-        $subscription->updateAttributes(['endAt' => Carbon::now()->subDays(5)]);
+        $oldGracePeriod = $subscription->ends_at;
+        $subscription->updateAttributes(['ends_at' => Carbon::now()->subDays(5)]);
 
         $this->assertFalse($subscription->active());
         $this->assertTrue($subscription->cancelled());
         $this->assertFalse($subscription->onGracePeriod());
-        $subscription->updateAttributes(['endAt' => $oldGracePeriod]);
+        $subscription->updateAttributes(['ends_at' => $oldGracePeriod]);
 
         // Resume Subscription
         $subscription->resume();
@@ -79,7 +79,7 @@ class CashierTest extends TestCase
         // Swap Plan
         $subscription->swap('monthly-10-2');
 
-        $this->assertEquals('monthly-10-2', $subscription->stripePlan);
+        $this->assertEquals('monthly-10-2', $subscription->stripe_plan);
 
         // Invoice Tests
         $invoice = $user->invoices()[1];
@@ -97,7 +97,9 @@ class CashierTest extends TestCase
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-            ->withCoupon('coupon-1')->create($this->getTestToken());
+            ->withCoupon('coupon-1')
+            ->create($this->getTestToken());
+
         $subscription = $user->subscription('main');
 
         $this->assertTrue($user->subscribed('main'));
@@ -120,9 +122,11 @@ class CashierTest extends TestCase
     {
         $user = new User();
         $this->assertFalse($user->onGenericTrial());
-        $user->trialEndAt = Carbon::tomorrow();
+
+        $user->trial_ends_at = Carbon::tomorrow();
         $this->assertTrue($user->onGenericTrial());
-        $user->trialEndAt = Carbon::today()->subDays(5);
+
+        $user->trial_ends_at = Carbon::today()->subDays(5);
         $this->assertFalse($user->onGenericTrial());
     }
 
@@ -132,12 +136,14 @@ class CashierTest extends TestCase
 
         // Create Subscription
         $user->newSubscription('main', 'monthly-10-1')
-            ->trialDays(7)->create($this->getTestToken());
+            ->trialDays(7)
+            ->create($this->getTestToken());
+
         $subscription = $user->subscription('main');
 
         $this->assertTrue($subscription->active());
         $this->assertTrue($subscription->onTrial());
-        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trialEndAt->day);
+        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
 
         // Cancel Subscription
         $subscription->cancel();
@@ -151,7 +157,7 @@ class CashierTest extends TestCase
         $this->assertTrue($subscription->active());
         $this->assertFalse($subscription->onGracePeriod());
         $this->assertTrue($subscription->onTrial());
-        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trialEndAt->day);
+        $this->assertEquals(Carbon::today()->addDays(7)->day, $subscription->trial_ends_at->day);
     }
 
     public function testApplyingCouponsToExistingCustomers()
@@ -181,8 +187,8 @@ class CashierTest extends TestCase
             'type' => 'customer.subscription.deleted',
             'data' => [
                 'object' => [
-                    'id' => $subscription->stripeId,
-                    'customer' => $user->stripeId,
+                    'id' => $subscription->stripe_id,
+                    'customer' => $user->stripe_id,
                 ],
             ],
         ]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -85,30 +85,30 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
         // Structure :
 
-        $db->createCommand()->createTable('subscription', [
+        $db->createCommand()->createTable('subscriptions', [
             'id' => 'pk',
-            'userId' => 'integer not null',
+            'user_id' => 'integer not null',
             'name' => 'string not null',
-            'stripeId' => 'string not null',
-            'stripePlan' => 'string not null',
+            'stripe_id' => 'string not null',
+            'stripe_plan' => 'string not null',
             'quantity' => 'integer not null',
-            'trialEndAt' => 'timestamp null default null',
-            'endAt' => 'timestamp null default null',
-            'createdAt' => 'timestamp null default null',
-            'updatedAt' => 'timestamp null default null',
+            'trial_ends_at' => 'timestamp null default null',
+            'ends_at' => 'timestamp null default null',
+            'created_at' => 'timestamp null default null',
+            'updated_at' => 'timestamp null default null',
         ])->execute();
 
-        $db->createCommand()->createTable('user', [
+        $db->createCommand()->createTable('users', [
             'id' => 'pk',
             'username' => 'string',
             'email' => 'string',
-            'stripeId' => 'string',
-            'cardBrand' => 'string',
-            'cardLastFour' => 'string',
-            'trialEndAt' => 'timestamp null default null',
+            'stripe_id' => 'string',
+            'card_brand' => 'string',
+            'card_last_four' => 'string',
+            'trial_ends_at' => 'timestamp null default null',
         ])->execute();
 
-        $db->createCommand()->insert('user', [
+        $db->createCommand()->insert('users', [
             'username' => 'John Doe',
             'email' => 'johndoe@domain.com',
         ])->execute();

--- a/tests/data/User.php
+++ b/tests/data/User.php
@@ -20,7 +20,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public static function tableName()
     {
-        return 'user';
+        return 'users';
     }
 
     /**


### PR DESCRIPTION
1. Rename table `subscription` -> `subscriptions`
2. Require php 7.1, added type hints, return types
3. Rename columns in the `subscriptions` table
4. Update tests